### PR TITLE
Fix pods deployment target

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -22,3 +22,13 @@ target 'KOZUKAITYOU' do
   # https://firebase.google.com/docs/ios/setup#available-pods
   # pod 'Google-Mobile-Ads-SDK'
 end
+
+post_install do |installer|
+  installer.generated_projects.each do |project|
+    project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '17.0'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- set `IPHONEOS_DEPLOYMENT_TARGET` for all pods via a post install step

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687669e742bc8322b8e0621e4b75cf69