### PR TITLE
Add SwiftUI skeleton interface

### DIFF
--- a/KOZUKAITYOU/AddEntryView.swift
+++ b/KOZUKAITYOU/AddEntryView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct AddEntryView: View {
+    @State private var name: String = ""
+    @State private var quantity: String = ""
+    @State private var amount: String = ""
+
+    var body: some View {
+        Form {
+            Section(header: Text("Entry")) {
+                TextField("Name", text: $name)
+                TextField("Quantity", text: $quantity)
+                    .keyboardType(.numberPad)
+                TextField("Amount", text: $amount)
+                    .keyboardType(.numberPad)
+            }
+            Button("Save") {
+                // Placeholder for save logic
+            }
+        }
+        .navigationTitle("Add Item")
+    }
+}
+
+struct AddEntryView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView { AddEntryView() }
+    }
+}

--- a/KOZUKAITYOU/AppDelegate.swift
+++ b/KOZUKAITYOU/AppDelegate.swift
@@ -10,36 +10,17 @@ import UIKit
 import CoreData
 import Firebase
 import IQKeyboardManager
+import SwiftUI
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        let display: CGRect = UIScreen.main.bounds
-              // 取得ディスプレイに対応したStoryBoardをrootViewController(最初に表示されるもの)にする。
-//              if display.size.height == 568 {
-//                  // iPhone 4S の場合 (Unit is Point.)
-//                  let storyboard = UIStoryboard(name: "SE", bundle: nil)
-//                  let rootViewController: UIViewController? = storyboard.instantiateInitialViewController()
-//                  window?.rootViewController = rootViewController
-//              }
-//              else if display.size.height == 667 {
-//                  // iPhone 6 の場合
-//                  let storyboard = UIStoryboard(name: "Main", bundle: nil)
-//                  let rootViewController: UIViewController? = storyboard.instantiateInitialViewController()
-//                  window?.rootViewController = rootViewController
-//              }
-//              else if display.size.height == 736 {
-//                  // iPhone 6 Plus の場合
-//                  let storyboard = UIStoryboard(name: "Main", bundle: nil)
-//                  let rootViewController: UIViewController? = storyboard.instantiateInitialViewController()
-//                  window?.rootViewController = rootViewController
-//              }else{
-                let storyboad = UIStoryboard(name: "Main", bundle: nil)
-                let rootViewController: UIViewController? = storyboad.instantiateInitialViewController()
-                window?.rootViewController = rootViewController
-//              }
+        window = UIWindow(frame: UIScreen.main.bounds)
+        window?.rootViewController = UIHostingController(rootView: ContentView())
+        window?.makeKeyAndVisible()
+
         IQKeyboardManager.shared().isEnabled = true
         FirebaseApp.configure()
         return true

--- a/KOZUKAITYOU/BudgetView.swift
+++ b/KOZUKAITYOU/BudgetView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct BudgetView: View {
+    var body: some View {
+        Text("Budget Settings")
+            .padding()
+            .navigationTitle("Budget")
+    }
+}
+
+struct BudgetView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView { BudgetView() }
+    }
+}

--- a/KOZUKAITYOU/ContentView.swift
+++ b/KOZUKAITYOU/ContentView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        TabView {
+            HomeView()
+                .tabItem {
+                    Label("Home", systemImage: "house")
+                }
+            NavigationView {
+                AddEntryView()
+            }
+            .tabItem {
+                Label("Add", systemImage: "plus.circle")
+            }
+            NavigationView {
+                BudgetView()
+            }
+            .tabItem {
+                Label("Budget", systemImage: "chart.bar")
+            }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/KOZUKAITYOU/HistoryView.swift
+++ b/KOZUKAITYOU/HistoryView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct HistoryView: View {
+    var body: some View {
+        List {
+            NavigationLink("Monthly Overview", destination: Text("Monthly Details"))
+            NavigationLink("Yearly Overview", destination: Text("Yearly Details"))
+        }
+        .navigationTitle("History")
+    }
+}
+
+struct HistoryView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView { HistoryView() }
+    }
+}

--- a/KOZUKAITYOU/HomeView.swift
+++ b/KOZUKAITYOU/HomeView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+        NavigationView {
+            VStack {
+                Text("Home Screen")
+                    .font(.largeTitle)
+                    .padding()
+                NavigationLink("View History", destination: HistoryView())
+                NavigationLink("Settings", destination: SettingsView())
+            }
+            .navigationTitle("Kodukaityou")
+        }
+    }
+}
+
+struct HomeView_Previews: PreviewProvider {
+    static var previews: some View {
+        HomeView()
+    }
+}

--- a/KOZUKAITYOU/LoginView.swift
+++ b/KOZUKAITYOU/LoginView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct LoginView: View {
+    @State private var email: String = ""
+    @State private var password: String = ""
+
+    var body: some View {
+        Form {
+            TextField("Email", text: $email)
+                .autocapitalization(.none)
+                .textContentType(.emailAddress)
+            SecureField("Password", text: $password)
+            Button("Login") {
+                // Placeholder for login logic
+            }
+        }
+        .navigationTitle("Login")
+    }
+}
+
+struct LoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView { LoginView() }
+    }
+}

--- a/KOZUKAITYOU/SettingsView.swift
+++ b/KOZUKAITYOU/SettingsView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        List {
+            NavigationLink("Login", destination: LoginView())
+            NavigationLink("Sign Up", destination: SignUpView())
+        }
+        .navigationTitle("Settings")
+    }
+}
+
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView { SettingsView() }
+    }
+}

--- a/KOZUKAITYOU/SignUpView.swift
+++ b/KOZUKAITYOU/SignUpView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct SignUpView: View {
+    @State private var email: String = ""
+    @State private var password: String = ""
+
+    var body: some View {
+        Form {
+            TextField("Email", text: $email)
+                .autocapitalization(.none)
+                .textContentType(.emailAddress)
+            SecureField("Password", text: $password)
+            Button("Sign Up") {
+                // Placeholder for signup logic
+            }
+        }
+        .navigationTitle("Sign Up")
+    }
+}
+
+struct SignUpView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView { SignUpView() }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The repository already includes a `GoogleService-Info.plist` file for Firebase c
 - Charts for visualizing spending
 - Support for Firebase Analytics and FirebaseUI authentication
 - UI utilities such as IQKeyboardManager and SVProgressHUD
+- SwiftUI interface with placeholder screens
+  - Tab-based navigation replacing storyboard
 
 ## License
 


### PR DESCRIPTION
## Summary
- replace `ContentView` with a tab-based SwiftUI interface
- add several placeholder SwiftUI screens (Home, AddEntry, Budget, History, Settings, Login, SignUp)
- mention SwiftUI tab navigation in README

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687773bba77c8322b9fab6e49db9e3ff