### PR TITLE
Add basic English mode

### DIFF
--- a/KOZUKAITYOU/AddViewController.swift
+++ b/KOZUKAITYOU/AddViewController.swift
@@ -111,21 +111,30 @@ class AddViewController: UIViewController, UIPickerViewDelegate, UIPickerViewDat
         // 入力チェック
         // 個数が未入力の場合は警告を表示
         if kosu.text?.isEmpty == true {
-            let alert = UIAlertController(title: "警告！", message:"個数が入力されていません！", preferredStyle: .alert)
+            let alert = UIAlertController(title: localized(japanese: "警告！", english: "Warning!"),
+                                          message: localized(japanese: "個数が入力されていません！",
+                                                                english: "Count is missing!"),
+                                          preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK!", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             self.view.endEditing(true)
             return
         // 単価が未入力の場合は警告を表示
         }else if tanka.text?.isEmpty == true{
-            let alert = UIAlertController(title: "警告！", message:"単価が入力されていません！", preferredStyle: .alert)
+            let alert = UIAlertController(title: localized(japanese: "警告！", english: "Warning!"),
+                                          message: localized(japanese: "単価が入力されていません！",
+                                                                english: "Unit price is missing!"),
+                                          preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK!", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             self.view.endEditing(true)
             return
         // 名称が未入力の場合は警告を表示
         }else if name.text?.isEmpty == true {
-            let alert = UIAlertController(title: "警告！", message:"名称が入力されていません！", preferredStyle: .alert)
+            let alert = UIAlertController(title: localized(japanese: "警告！", english: "Warning!"),
+                                          message: localized(japanese: "名称が入力されていません！",
+                                                                english: "Name is missing!"),
+                                          preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK!", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             self.view.endEditing(true)
@@ -280,11 +289,11 @@ class AddViewController: UIViewController, UIPickerViewDelegate, UIPickerViewDat
         let tanka2 :String = "単価" + String(tanka.text!) + "円\n"
         let kosuu2 :String = "個数" + kosuu + "\n"
         let kei :String = "小計" + goukeib
-        let nitiji:String = "\n日時" + dateFormatter.string(from: date!)
-  print("アラート")
-        let title = "登録したよ！"
-        let message = "登録されました！\n" + "登録されたデータ\n" + names + tanka2 + kosuu2 + kei + nitiji
-       let okText = "ok"
+        let nitiji:String = "\n" + localized(japanese: "日時", english: "Date") + dateFormatter.string(from: date!)
+        print("アラート")
+        let title = localized(japanese: "登録したよ！", english: "Saved!")
+        let message = localized(japanese: "登録されました！\n登録されたデータ\n", english: "Saved!\nSaved data\n") + names + tanka2 + kosuu2 + kei + nitiji
+        let okText = "OK"
         let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertController.Style.alert)
         let okayButton = UIAlertAction(title: okText, style: UIAlertAction.Style.cancel, handler: nil)
         alert.addAction(okayButton)

--- a/KOZUKAITYOU/InmoneyViewController.swift
+++ b/KOZUKAITYOU/InmoneyViewController.swift
@@ -41,13 +41,17 @@ class InmoneyViewController: UIViewController {
     @IBAction func PUSHSAVE(){
         //-------入力確認・警告----------------↓
         if Tuki.text?.isEmpty == true {
-            let alert = UIAlertController(title: "警告！", message:"月が入力されていません！", preferredStyle: .alert)
+            let alert = UIAlertController(title: localized(japanese: "警告！", english: "Warning!"),
+                                          message: localized(japanese: "月が入力されていません！", english: "Month is missing!"),
+                                          preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK!", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             self.view.endEditing(true)
             return
         }else if Niti.text?.isEmpty == true {
-            let alert = UIAlertController(title: "警告！", message:"日付が入力されていません！", preferredStyle: .alert)
+            let alert = UIAlertController(title: localized(japanese: "警告！", english: "Warning!"),
+                                          message: localized(japanese: "日付が入力されていません！", english: "Day is missing!"),
+                                          preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK!", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             self.view.endEditing(true)
@@ -57,13 +61,17 @@ class InmoneyViewController: UIViewController {
         niti = Int(Niti.text!)!
         tuki = Int(Tuki.text!)!
         if niti > 31 {
-            let alert = UIAlertController(title: "警告！", message:"日付が存在しません！",   preferredStyle: .alert)
+            let alert = UIAlertController(title: localized(japanese: "警告！", english: "Warning!"),
+                                          message: localized(japanese: "日付が存在しません！", english: "Invalid day!"),
+                                          preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK!", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             self.view.endEditing(true)
             return
         }else if tuki > 12{
-            let alert = UIAlertController(title: "警告！", message:"そんな月はねえ！", preferredStyle: .alert)
+            let alert = UIAlertController(title: localized(japanese: "警告！", english: "Warning!"),
+                                          message: localized(japanese: "そんな月はねえ！", english: "Invalid month!"),
+                                          preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK!", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             self.view.endEditing(true)

--- a/KOZUKAITYOU/Localization.swift
+++ b/KOZUKAITYOU/Localization.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum Language {
+    case japanese
+    case english
+
+    static var current: Language {
+        if Locale.current.languageCode == "ja" {
+            return .japanese
+        } else {
+            return .english
+        }
+    }
+}
+
+func localized(japanese: String, english: String) -> String {
+    switch Language.current {
+    case .japanese:
+        return japanese
+    case .english:
+        return english
+    }
+}

--- a/KOZUKAITYOU/SavebudgetViewController.swift
+++ b/KOZUKAITYOU/SavebudgetViewController.swift
@@ -50,55 +50,73 @@ class SavebudgetViewController: UIViewController {
     @IBAction func saveWorld(_ sender: Any){
         //---------===================isEmpty警告ーーーーーーーーーーーーーーーーーーーー
         if a.text?.isEmpty == true {
-            let alert = UIAlertController(title: "警告！", message:"A費が入力されていません！", preferredStyle: .alert)
+            let alert = UIAlertController(title: localized(japanese: "警告！", english: "Warning!"),
+                                          message: localized(japanese: "A費が入力されていません！", english: "Field A is empty!"),
+                                          preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK!", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             self.view.endEditing(true)
             return
         }else if b.text?.isEmpty == true{
-            let alert = UIAlertController(title: "警告！", message:"B費が入力されていません！", preferredStyle: .alert)
+            let alert = UIAlertController(title: localized(japanese: "警告！", english: "Warning!"),
+                                          message: localized(japanese: "B費が入力されていません！", english: "Field B is empty!"),
+                                          preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK!", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             self.view.endEditing(true)
             return
         }else if c.text?.isEmpty == true{
-            let alert = UIAlertController(title: "警告！", message:"C費が入力されていません！", preferredStyle: .alert)
+            let alert = UIAlertController(title: localized(japanese: "警告！", english: "Warning!"),
+                                          message: localized(japanese: "C費が入力されていません！", english: "Field C is empty!"),
+                                          preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK!", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             self.view.endEditing(true)
             return
         }else if d.text?.isEmpty == true{
-            let alert = UIAlertController(title: "警告！", message:"D費が入力されていません！", preferredStyle: .alert)
+            let alert = UIAlertController(title: localized(japanese: "警告！", english: "Warning!"),
+                                          message: localized(japanese: "D費が入力されていません！", english: "Field D is empty!"),
+                                          preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK!", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             self.view.endEditing(true)
             return
         }else if e.text?.isEmpty == true{
-            let alert = UIAlertController(title: "警告！", message:"E費が入力されていません！", preferredStyle: .alert)
+            let alert = UIAlertController(title: localized(japanese: "警告！", english: "Warning!"),
+                                          message: localized(japanese: "E費が入力されていません！", english: "Field E is empty!"),
+                                          preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK!", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             self.view.endEditing(true)
             return
         }else if f.text?.isEmpty == true{
-            let alert = UIAlertController(title: "警告！", message:"F費が入力されていません！", preferredStyle: .alert)
+            let alert = UIAlertController(title: localized(japanese: "警告！", english: "Warning!"),
+                                          message: localized(japanese: "F費が入力されていません！", english: "Field F is empty!"),
+                                          preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK!", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             self.view.endEditing(true)
             return
         }else if g.text?.isEmpty == true{
-            let alert = UIAlertController(title: "警告！", message:"G費が入力されていません！", preferredStyle: .alert)
+            let alert = UIAlertController(title: localized(japanese: "警告！", english: "Warning!"),
+                                          message: localized(japanese: "G費が入力されていません！", english: "Field G is empty!"),
+                                          preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK!", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             self.view.endEditing(true)
             return
         }else if h.text?.isEmpty == true{
-            let alert = UIAlertController(title: "警告！", message:"H費が入力されていません！", preferredStyle: .alert)
+            let alert = UIAlertController(title: localized(japanese: "警告！", english: "Warning!"),
+                                          message: localized(japanese: "H費が入力されていません！", english: "Field H is empty!"),
+                                          preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK!", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             self.view.endEditing(true)
             return
         }else if i.text?.isEmpty == true{
-            let alert = UIAlertController(title: "警告！", message:"I費が入力されていません！", preferredStyle: .alert)
+            let alert = UIAlertController(title: localized(japanese: "警告！", english: "Warning!"),
+                                          message: localized(japanese: "I費が入力されていません！", english: "Field I is empty!"),
+                                          preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK!", style: .default, handler: nil))
             present(alert, animated: true, completion: nil)
             self.view.endEditing(true)

--- a/KOZUKAITYOU/en.lproj/InfoPlist.strings
+++ b/KOZUKAITYOU/en.lproj/InfoPlist.strings
@@ -1,0 +1,1 @@
+"CFBundleDisplayName" = "Kodukaityou";

--- a/KOZUKAITYOU/ja.lproj/InfoPlist.strings
+++ b/KOZUKAITYOU/ja.lproj/InfoPlist.strings
@@ -1,0 +1,1 @@
+"CFBundleDisplayName" = "小遣い帳";

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kodukaityou
 
-Kodukaityou (小遣い帳) is an iOS application for managing your budget and expenses. The project is written in Swift and uses CocoaPods to manage its dependencies.
+Kodukaityou (小遣い帳) is an iOS application for managing your budget and expenses. The project is written in Swift and uses CocoaPods to manage its dependencies. The app now detects the device language and shows alerts in English when running on an English device.
 
 ## Requirements
 
@@ -38,6 +38,7 @@ The repository already includes a `GoogleService-Info.plist` file for Firebase c
 - Charts for visualizing spending
 - Support for Firebase Analytics and FirebaseUI authentication
 - UI utilities such as IQKeyboardManager and SVProgressHUD
+- Automatic English mode when the device language is set to English
 
 ## License
 


### PR DESCRIPTION
## Summary
- add simple `Localization` helper
- show localized alert messages in Add, Savebudget, and Inmoney screens
- include InfoPlist localizations
- document English mode in README

## Testing
- `swift --version`
- `swiftc --version`


------
https://chatgpt.com/codex/tasks/task_e_687c4c0d38948322b5106351487b495a